### PR TITLE
Small improvement to the code & dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
 [workspace]
 members = ["frontend", "backend"]
 resolver = "2"
+
+[workspace.dependencies]
+futures-util = "0.3.31"
+tokio-tungstenite = { version = "0.24.0" }
+tokio = { version = "1.40.0", features = ["full"] }
+serde = { version = "1.0.215", features = ["derive"] }
+anyhow = "1.0.94"
+chrono = "0.4.39"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-futures-util = "0.3.31"
-tokio-tungstenite = { version = "0.24.0" }
-tokio = { version = "1.40.0", features = ["full"] }
-serde = { version = "1.0.215", features = ["derive"] }
+futures-util.workspace = true
+tokio-tungstenite.workspace = true
+tokio.workspace = true
+serde.workspace = true
 sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio-rustls"] }
 serde_json = "1.0.133"
-anyhow = "1.0.93"
-chrono = "0.4.38"
+anyhow.workspace = true
+chrono.workspace = true
 jwt-simple = "0.12.11"

--- a/backend/src/channel.rs
+++ b/backend/src/channel.rs
@@ -28,7 +28,7 @@ impl Channel {
                 .expect("failed insert into to table \"messages\"");
             }
         });
-        Ok(Self { sender: sender })
+        Ok(Self { sender })
     }
     pub fn send(&self, msg: ChannelMessage) -> Result<()> {
         self.sender.send(msg)?;

--- a/backend/src/context.rs
+++ b/backend/src/context.rs
@@ -26,13 +26,15 @@ impl Context {
         let connections = Arc::new(RwLock::new(HashMap::new()));
         let channel = Channel::new(pg_pool.clone(), connections.clone()).await?;
         Ok(Self {
-            key: key,
-            pg_pool: pg_pool,
-            channel: channel,
-            connections: connections,
+            key,
+            pg_pool,
+            channel,
+            connections,
         })
     }
-    pub fn key(&self) -> &HS256Key { &self.key }
+    pub fn key(&self) -> &HS256Key {
+        &self.key
+    }
     pub async fn contains(&self, username: &str) -> bool {
         self.connections.read().await.contains_key(username)
     }

--- a/backend/src/endpoints.rs
+++ b/backend/src/endpoints.rs
@@ -15,7 +15,7 @@ use tokio_tungstenite::{accept_async, tungstenite::Message};
 pub async fn signin(context: Context, mut socket: TcpStream, body: &str) -> Result<()> {
     let authrequest: AuthRequest = serde_json::from_str(body)?;
     if !authrequest.is_valid() {
-        socket
+        let _ = socket
             .write(&Response::new(409, "Conflict", "Wrong format"))
             .await?;
         return Ok(());
@@ -29,14 +29,14 @@ pub async fn signin(context: Context, mut socket: TcpStream, body: &str) -> Resu
         if !context.contains(authrequest.username).await {
             let claims = Claims::create(Duration::from_mins(1)).with_subject(authrequest.username);
             let token = context.key().authenticate(claims)?;
-            socket.write(&Response::new(200, "OK", &token)).await?;
+            let _ = socket.write(&Response::new(200, "OK", &token)).await?;
         } else {
-            socket
+            let _ = socket
                 .write(&Response::new(409, "Conflict", "Already in"))
                 .await?;
         }
     } else {
-        socket
+        let _ = socket
             .write(&Response::new(
                 401,
                 "Unauthorized",
@@ -50,7 +50,7 @@ pub async fn signin(context: Context, mut socket: TcpStream, body: &str) -> Resu
 pub async fn signup(context: Context, mut socket: TcpStream, body: &str) -> Result<()> {
     let authrequest: AuthRequest = serde_json::from_str(body)?;
     if !authrequest.is_valid() {
-        socket
+        let _ = socket
             .write(&Response::new(409, "Conflict", "Wrong format"))
             .await?;
         return Ok(());
@@ -60,14 +60,14 @@ pub async fn signup(context: Context, mut socket: TcpStream, body: &str) -> Resu
         .execute(&context.pg_pool)
         .await?;
     if query.rows_affected() == 0 {
-        socket.write(&Response::new(200, "OK", "Success")).await?;
+        let _ = socket.write(&Response::new(200, "OK", "Success")).await?;
         sqlx::query("INSERT INTO users (username, password) VALUES ($1, $2)")
             .bind(authrequest.username)
             .bind(authrequest.password)
             .execute(&context.pg_pool)
             .await?;
     } else {
-        socket
+        let _ = socket
             .write(&Response::new(409, "Conflict", "Already exists"))
             .await?;
     }

--- a/backend/src/userconnection.rs
+++ b/backend/src/userconnection.rs
@@ -18,8 +18,8 @@ impl UserConnection {
         })
         .abort_handle();
         Self {
-            sender: sender,
-            aborthandle: aborthandle,
+            sender,
+            aborthandle,
         }
     }
     pub fn send(&self, msg: ChannelMessage) {

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.215", features = ["derive"] }
+serde.workspace = true
 cursive = { version = "0.21.1", features = ["ansi"] }
-tokio = { version = "1.42.0", features = ["full"] }
+tokio.workspace = true
 ureq = { version = "2.12.1", features = ["json"] }
-tokio-tungstenite = "0.24.0"
-futures-util = "0.3.31"
+tokio-tungstenite.workspace = true
+futures-util.workspace = true
 cursive_core = "0.4.6"
 crossterm = "0.28.1"
-anyhow = "1.0.94"
-chrono = "0.4.39"
+anyhow.workspace = true
+chrono.workspace = true
 argh = "0.1.13"


### PR DESCRIPTION
# First commit
Contains some tiny changes that make code a little bit more idiomatic

# Second commit
Exploit `cargo` ability to manage common dependencies of all crates in a workspace. Now you do not need to look through all crates to update a common dependency.

For example previously `anyhow` & `chrono` was switched to newer version in `frontend` crate but `backend` crate used old versions of those dependencies.